### PR TITLE
fix broken content-type in the multipart form that caused 403 HTTP status.

### DIFF
--- a/Sources/NyrisSDK/Services/ImageMatchingService.swift
+++ b/Sources/NyrisSDK/Services/ImageMatchingService.swift
@@ -169,7 +169,7 @@ final public class ImageMatchingService : BaseService, XOptionsProtocol {
         
         multipartBody += "--\(multipartBoundary)\(newline)"
         multipartBody += "Content-Disposition:form-data; name=\"image\"; filename=\"image.jpeg\"\(newline)"
-        multipartBody += "Content-Type: \"image/jpeg\"\(newline)\(newline)"
+        multipartBody += "Content-Type: image/jpeg\(newline)\(newline)"
         
         guard let formData = multipartBody.data(using: .utf8), let endBoundryData = endBoundry.data(using: .utf8) else {
             return nil


### PR DESCRIPTION
The /find/v1.1 api with filter was returning  a 403 due to extra quotes in the content-type inside the multiform.
This PR removes the quotes to ensure the server doesn't reject the request.